### PR TITLE
Adds listItemText as a styleable element

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -109,10 +109,11 @@ export default (styles) => ({
         else {
           bullet = createElement(Text, { key: state.key, style: styles.listItemBullet }, '\u2022 ')
         }
+        const listItemText = createElement(Text, { key: state.key + 1, style: styles.listItemText }, output(item, state))
         return createElement(View, {
           key: i,
           style: styles.listItem
-        }, [bullet, output(item, state)])
+        }, [bullet, listItemText])
       })
       return createElement(View, { key: state.key, style: styles.list }, items)
     }

--- a/styles.js
+++ b/styles.js
@@ -53,6 +53,12 @@ const styles = {
   listItem: {
     flexDirection: 'row',
   },
+  listItemText: {
+    flexDirection: 'row',
+    flexWrap: 'wrap',
+    alignItems: 'flex-start',
+    justifyContent: 'flex-start',
+  },
   listItemBullet: {
     fontSize: 20,
     lineHeight: 20,


### PR DESCRIPTION
Currently, you can only style a `list`, a `listItem` or a `listItem`'s `listItemNumber` or `listItemBullet`, depending on whether it is ordered or not. Because a `listItem` is a `<View>` element, the only way to style the text inside it is to add styles to `text`. This overrides every other `text` element.

Also, by default, `listItem`s should wrap within their parent element. This adds the necessary react-native-flavored flexbox styling to the new `listItemText` by default.

This is my first PR. Be gentle!