### PR TITLE
fixes: failing when using __ for text underline

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -197,7 +197,7 @@ export default (styles) => ({
   u: {
     react: (node, output, state) => {
       state.withinText = true
-      return createElement(View, {
+      return createElement(Text, {
         key: state.key,
         style: styles.u
       }, output(node.content, state))

--- a/styles.js
+++ b/styles.js
@@ -125,8 +125,7 @@ const styles = {
     color: '#222222',
   },
   u: {
-    borderColor: '#222222',
-    borderBottomWidth: 1,
+    textDecorationLine: 'underline'
   },
   video: {
     width: 300,


### PR DESCRIPTION
I was getting a 
```
Views nested within a <Text> must have a width and height
```
when I was using `__underscore__` for a markup, this fixed it for me.