### PR TITLE
added try catch with custom errorHandler to solve unexpected formats

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,15 +46,23 @@ class Markdown extends Component {
   }
 
   renderContent = (children: string) => {
-    const mergedStyles = Object.assign(styles, this.props.styles)
+    try {
+      const mergedStyles = Object.assign(styles, this.props.styles)
 
-    const rules = this.postProcessRules(_.merge({}, SimpleMarkdown.defaultRules, initialRules(mergedStyles), this.props.rules))
-    const child = Array.isArray(this.props.children)
-      ? this.props.children.join('')
-      : this.props.children
-    const blockSource = child + '\n\n'
-    const tree = SimpleMarkdown.parserFor(rules)(blockSource, { inline: false })
-    return SimpleMarkdown.reactFor(SimpleMarkdown.ruleOutput(rules, 'react'))(tree)
+      const rules = this.postProcessRules(_.merge({}, SimpleMarkdown.defaultRules, initialRules(mergedStyles), this.props.rules))
+      const child = Array.isArray(this.props.children)
+        ? this.props.children.join('')
+        : this.props.children
+      const blockSource = child + '\n\n'
+      const tree = SimpleMarkdown.parserFor(rules)(blockSource, { inline: false })
+      return SimpleMarkdown.reactFor(SimpleMarkdown.ruleOutput(rules, 'react'))(tree)
+    } catch(error) {
+      if(this.props.errorHandler) {
+        this.props.errorHandler(error,children);
+      } else {
+        console.error(error);
+      }
+    }
   }
 
   shouldComponentUpdate(nextProps, nextState) {


### PR DESCRIPTION
I found weird errors like adding wrong formats such as **[b][something]**. In release mode app simply crashes and is critical to have an error handler to avoid crash and instead, avoid rendering markdown for example. 

You can use errorHandler as follows:

```javascript
const errorHandler = (error, children) => {
  /* do something here to recover or throw error */
}

<SimpleMarkdown errorHandler={errorHandler}>
  Example of **Markdown** style
</SimpleMarkdown>
```

I hope you find this useful :)