### PR TITLE
corrected readme paragraph to be <View>

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,7 +133,7 @@ Example:
 | `link` | `<Text>` | - |
 | `list` | `<View>` | Also `listItem` (`<View>`), `listItemBullet` (`<Text>`), `listItemBulletType` (`Unicode character`), `listItemNumber` (`<Text>`) and `listItemText` (`<Text>`) |
 | `mailTo` | `<Text>` | - |
-| `paragraph` | `<Text>` | - |
+| `paragraph` | `<View>` | - |
 | `plainText` | `<Text>` | Used for styling text without any associated styles |
 | `strong` | `<Text>` | - |
 | `table` | `<View>` | - |


### PR DESCRIPTION
The element for paragraph changed in https://github.com/CharlesMangwa/react-native-simple-markdown/commit/3b4147bd8729bb4875f0a2dbf2757e493d227cab#diff-bd031b8256732079443e550363389c0eR144 from `<Text>` to `<View>` but the Readme still shows it as a `<Text>`.