### PR TITLE
Fix deleted text to be line-through text

### DIFF
--- a/styles.js
+++ b/styles.js
@@ -15,7 +15,7 @@ const styles = {
     fontWeight: '500',
   },
   del: {
-    containerBackgroundColor: '#222222',
+    textDecorationLine: 'line-through',
   },
   em: {
     fontStyle: 'italic',


### PR DESCRIPTION
Use `textDecorationLine: 'line-through'` to make deleted text be like really deleted text :)
![image](https://cloud.githubusercontent.com/assets/7809008/25040278/98b13b72-2108-11e7-9bd7-d69d954e4713.png)
