### PR TITLE
Should not mutate initial styles

### DIFF
--- a/index.js
+++ b/index.js
@@ -46,7 +46,7 @@ class Markdown extends PureComponent<DefaultProps, Props, void> {
 
   _renderContent = (children: string): React$Element<any> => {
     try {
-      const mergedStyles = Object.assign(initialStyles, this.props.styles)
+      const mergedStyles = Object.assign({}, initialStyles, this.props.styles)
       const rules = this._postProcessRules(_.merge({}, SimpleMarkdown.defaultRules, initialRules(mergedStyles), this.props.rules))
       const child = Array.isArray(this.props.children)
         ? this.props.children.join('')


### PR DESCRIPTION
Current code is mutating initial state thus affecting other instance of `<Markdown>` with `styles` prop.