### PR TITLE
fix(rules): typo in url rule

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -217,7 +217,7 @@ export default (styles) => ({
       return createElement(Text, {
         key: state.key,
         style: styles.url,
-        onPress: openURL(node.target)
+        onPress: openUrl(node.target)
       }, output(node.content, state))
     }
   }


### PR DESCRIPTION
The local function is called openUrl, not openURL.