### PR TITLE
add onLinkPress custom function

### DIFF
--- a/index.js
+++ b/index.js
@@ -12,7 +12,8 @@ type Props = {
   children?: string,
   rules: Object,
   whitelist: Array,
-  blacklist: Array
+  blacklist: Array,
+  onLinkPress: Function
 }
 
 type DefaultProps = Props & {
@@ -49,7 +50,7 @@ class Markdown extends Component<DefaultProps, Props, void> {
         _.merge(
           {},
           SimpleMarkdown.defaultRules,
-          initialRules(mergedStyles),
+          initialRules(mergedStyles, this.props),
           this.props.rules
         )
       )

--- a/rules.js
+++ b/rules.js
@@ -3,7 +3,7 @@ import { Image, Text, View, Linking } from 'react-native'
 import SimpleMarkdown from 'simple-markdown'
 import _ from 'lodash'
 
-export default (styles) => ({
+export default (styles, props) => ({
   autolink: {
     react: (node, output, state) => {
       state.withinText = true
@@ -105,10 +105,12 @@ export default (styles) => ({
       const openUrl = (url) => {
         Linking.openURL(url).catch(error => console.warn('An error occurred: ', error))
       }
+      const onPress = props.onLinkPress ? props.onLinkPress : openUrl
+
       return createElement(Text, {
         style: node.target.match(/@/) ? styles.mailTo : styles.link,
         key: state.key,
-        onPress: () => openUrl(node.target)
+        onPress: () => onPress(node.target)
       }, output(node.content, state))
     }
   },


### PR DESCRIPTION
Adds prop for a custom function to run on link press, taking url as only parameter.  Allows intercepting certain urls (for in-app routing, preventing/redirecting certain domains, etc).  Falls back to Linking.canOpenUrl if not present