### PR TITLE
fix(config): use semantic versioning

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "react-native-simple-markdown",
   "repository": "https://github.com/CharlesMangwa/react-native-simple-markdown",
-  "version": "next",
+  "version": "1.0.0",
   "description":
     "Render Markdown in React Native with native components (iOS & Android)",
   "main": "lib/index.js",


### PR DESCRIPTION
Package versioning should follow semantic versioning rules. In the Latest Yarn version (1.5.1), this is a strict policy and does not allow you to install this package.