### PR TITLE
Added reflink support

### DIFF
--- a/rules.js
+++ b/rules.js
@@ -82,12 +82,17 @@ export default (styles) => ({
   },
   image: {
     react: (node, output, state) => {
-      return createElement(Image, {
-        key: state.key,
-        resizeMode: styles.resizeMode ? styles.resizeMode : 'contain',
-        source: { uri: node.target },
-        style: node.target.match(/youtu|vimeo/) ? styles.video : styles.image
-      })
+      return node.target ?
+        createElement(Image, {
+          key: state.key,
+          resizeMode: styles.resizeMode ? styles.resizeMode : 'contain',
+          source: { uri: node.target },
+          style: node.target.match(/youtu|vimeo/) ? styles.video : styles.image
+        }) :
+        createElement(Text, {
+          key: state.key,
+          style: styles.text
+        }, node.alt);
     }
   },
   inlineCode: {
@@ -106,9 +111,9 @@ export default (styles) => ({
         Linking.openURL(url).catch(error => console.warn('An error occurred: ', error))
       }
       return createElement(Text, {
-        style: node.target.match(/@/) ? styles.mailTo : styles.link,
+        style: node.target ? node.target.match(/@/) ? styles.mailTo : styles.link : styles.text,
         key: state.key,
-        onPress: () => openUrl(node.target)
+        onPress: () => node.target ? openUrl(node.target) : null
       }, output(node.content, state))
     }
   },


### PR DESCRIPTION
The node.target was undefined when we didn't specify the link reference
or when there was no break line between the link and the reference.
It happened for image too.