### PR TITLE
Bug fix for when text is in between tags

### DIFF
--- a/src/rules.js
+++ b/src/rules.js
@@ -281,6 +281,8 @@ export default styles => ({
           word,
         )
       })
+      //Reset withinText
+      parentState.withinText = false
       return words
     },
   },


### PR DESCRIPTION
Currently, if you have `**bold text** normal text` we still apply the withinText boolean. This is to reset the flag in between text tags, meaning that the normal text will have the plainText style applied. 