### PR TITLE
Update package.json to use https instead of git

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   "author": "Charles Mangwa <charlesmangwa@gmail.com> (http://carlito.ninja)",
   "dependencies": {
     "lodash": "^4.15.0",
-    "simple-markdown": "git://github.com/CharlesMangwa/simple-markdown.git"
+    "simple-markdown": "https://github.com/CharlesMangwa/simple-markdown"
   },
   "peerDependencies": {
     "react-native": "*"


### PR DESCRIPTION
Some environments (e.g. CircleCI) have an issue with cloning from NPM dependencies spec'd with a `git://` URL. This PR switches to an HTTPS-based URL instead.

Reference: https://support.circleci.com/hc/en-us/articles/360009699913-Can-t-read-from-remote-git-repository-during-npm-install

This PR is published as [@carsondarling/react-native-simple-markdown@1.1.1](https://www.npmjs.com/package/@carsondarling/react-native-simple-markdown/v/1.1.1)